### PR TITLE
Added margin-right to lines, to match margin-left

### DIFF
--- a/lpcg/model_data.py
+++ b/lpcg/model_data.py
@@ -51,6 +51,7 @@ p {
  text-align: left;
  margin-left: 30px;
  text-indent: -30px;
+ margin-right: 30px;
 }
 
 .cloze {


### PR DESCRIPTION
On AnkiDroid, text sometimes flowed past the right edge of the screen