### PR TITLE
Set up RTD with new config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF
+formats:
+   - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+   version: 3.8
+   install:
+    - requirements: requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,4 @@
-pytest==5.4.3
-pytest-cov==2.10.0
-pylint>=2.5.2,<3.0
-yapf>=0.30.0,<1.0
-mypy>=0.770,<1.0
 pip>=20.1
-
-pyqt5==5.15
-anki==2.1.43
-#ankirspy==2.1.43
-aqt==2.1.43
 
 sphinx==1.8.5
 sphinx_rtd_theme==0.5.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,11 @@
+-r requirements.txt
+
+pytest==5.4.3
+pytest-cov==2.10.0
+pylint>=2.5.2,<3.0
+yapf>=0.30.0,<1.0
+mypy>=0.770,<1.0
+
+pyqt5==5.15
+anki==2.1.44
+aqt==2.1.44


### PR DESCRIPTION
Main problem (I think) is that RTD is building with Python 3.7 and the new Anki packages are >=3.8, so I split out the requirements file into the parts that are only required for testing/development and the parts that are required for the docs as well.