### PR TITLE
Fix `QPushButton` Bug, upgrade to Qt6, and add multiple indent support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ docs/_build
 
 # anki add-on metadata file which appears when live-linking
 meta.json
+
+# build outputs
+src/import_dialog*.py

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,19 @@
 .PHONY: all docs forms zip clean
 
-all: docs forms zip
+all: docs 6forms zip
 docs:
 	$(MAKE) -C docs html
-forms: src/import_dialog.py
+forms: 5forms 6forms
+#forms: src/import_dialog.py
+5forms: $(patsubst designer/%_dialog.ui,src/%_dialog5.py,$(wildcard designer/*))
+6forms: $(patsubst designer/%_dialog.ui,src/%_dialog6.py,$(wildcard designer/*))
 zip: build.zip
 
-src/import_dialog.py: designer/import_dialog.ui 
+src/import_dialog5.py: designer/import_dialog.ui
 	pyuic5 $^ > $@
+
+src/import_dialog6.py: designer/import_dialog.ui
+	pyuic6 $^ > $@
 
 build.zip: src/*
 	rm -f $@

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+# language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/technical.rst
+++ b/docs/technical.rst
@@ -24,6 +24,11 @@ Line
     because the editor doesn’t use the same styling as the review window
     and this can't easily be customized.
 
+    Each indented line will render as indented using ``<span>`` tags. If
+    multiple indents are desired, use tabs to indent each line instead of
+    spaces. All leading spaces will be converted into a single indent whereas
+    each tab will be treated as a separate indent.
+
 Context
     Contains the several lines prior to *Line*,
     to give you an idea of what to recite.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ pip>=20.1
 
 # requirements needs to be just sphinx so we don't have to configure the
 # read the docs installation environment.
-sphinx==5.0.1
+sphinx==4.1.2
 sphinx_rtd_theme==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pip>=20.1
 
-sphinx==1.8.5
-sphinx_rtd_theme==0.5.0
+sphinx==5.0.1
+sphinx_rtd_theme==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pip>=20.1
 
-pyqt6==6.3.0
-PyQt6-WebEngine==6.3.0
-anki==2.1.53
-aqt==2.1.53
+# requirements needs to be just sphinx so we don't have to configure the
+# read the docs installation environment.
+sphinx==5.0.1
+sphinx_rtd_theme==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 pip>=20.1
 
-sphinx==5.0.1
-sphinx_rtd_theme==1.0.0
+pyqt6==6.3.0
+PyQt6-WebEngine==6.3.0
+anki==2.1.53
+aqt==2.1.53

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,11 +1,10 @@
--r requirements.txt
+-e requirements.txt
+
+sphinx==5.0.1
+sphinx_rtd_theme==1.0.0
 
 pytest==5.4.3
 pytest-cov==2.10.0
 pylint>=2.5.2,<3.0
 yapf>=0.30.0,<1.0
 mypy>=0.770,<1.0
-
-pyqt5==5.15.1
-anki==2.1.45rc2
-aqt==2.1.45rc2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
--e requirements.txt
+-r requirements.txt
 
 pyqt6==6.3.0
 PyQt6-WebEngine==6.3.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,9 @@
 -e requirements.txt
 
-sphinx==5.0.1
-sphinx_rtd_theme==1.0.0
+pyqt6==6.3.0
+PyQt6-WebEngine==6.3.0
+anki==2.1.53
+aqt==2.1.53
 
 pytest==5.4.3
 pytest-cov==2.10.0

--- a/src/lpcg_dialog.py
+++ b/src/lpcg_dialog.py
@@ -1,16 +1,15 @@
 import codecs
 
-# pylint: disable=no-name-in-module
-from PyQt5.QtWidgets import QDialog
-from PyQt5.QtGui import QDesktopServices
-from PyQt5.QtCore import QUrl
-
 import aqt
-from aqt.qt import QAction  # type: ignore
+from aqt.qt import QUrl, QDesktopServices, QDialog, qtmajor, QAction, Qt  # type: ignore
 from aqt.utils import getFile, showWarning, askUser, tooltip
 from anki.notes import Note
 
-from . import import_dialog as lpcg_form
+if qtmajor > 5:
+  from . import import_dialog6 as lpcg_form
+else:
+  from . import import_dialog5 as lpcg_form  # type: ignore
+
 from .gen_notes import add_notes, cleanse_text
 from . import models
 
@@ -24,10 +23,10 @@ class LPCGDialog(QDialog):
     front of lines). LPCG then processes it into notes with two lines of
     context and adds them to the user's collection.
     """
-    def __init__(self, mw):
+    def __init__(self, mw: aqt.main.AnkiQt):
+        QDialog.__init__(self)
         self.mw = mw
 
-        QDialog.__init__(self)
         self.form = lpcg_form.Ui_Dialog()
         self.form.setupUi(self)
         self.deckChooser = aqt.deckchooser.DeckChooser(
@@ -44,7 +43,7 @@ class LPCGDialog(QDialog):
         self.form.groupLinesSpin.setValue(self.addonConfig['defaultLinesInGroupsOf'])
 
     def accept(self):
-        "On close, create notes from the contents of the poem editor."
+        """On close, create notes from the contents of the poem editor."""
         title = self.form.titleBox.text().strip()
 
         if not title:
@@ -88,6 +87,12 @@ class LPCGDialog(QDialog):
             super(LPCGDialog, self).accept()
             self.mw.reset()
             tooltip("%i notes added." % notes_generated)
+
+        self.deckChooser.cleanup()
+
+    def reject(self):
+        self.deckChooser.cleanup()
+        super().reject()
 
     def onOpenFile(self):
         """

--- a/test/test_gen_notes.py
+++ b/test/test_gen_notes.py
@@ -84,6 +84,30 @@ class TestCleanseText:
         assert result[3] == f"{INDENT_HTML_START}To do it en masse,{INDENT_HTML_END}"
         assert result[4] == "Your remembering would turn out much worsal.X"
 
+    def test_multiple_indentation(self):
+        dijkstra = dedent("""
+		function Dijkstra(Graph, source):
+			for each vertex v in Graph.Vertices:
+				dist[v] ← INFINITY
+				prev[v] ← UNDEFINED
+				add v to Q
+			dist[source] ← 0
+			while Q is not empty:
+				u ← vertex in Q with min dist[u]
+				remove u from Q
+				for each neighbor v of u still in Q:
+					alt ← dist[u] + Graph.Edges(u, v)
+					if alt < dist[v] and dist[u] is not INFINITY:
+						dist[v] ← alt
+						prev[v] ← u
+			return dist[], prev[]
+		""").strip()
+        result = cleanse_text(dijkstra, MOCK_CLEANSE_CONFIG)
+        assert result[0] == "function Dijkstra(Graph, source):"
+        assert result[1] == f"{INDENT_HTML_START}for each vertex v in Graph.Vertices:{INDENT_HTML_END}"
+        assert result[2] == f"{INDENT_HTML_START*2}dist[v] ← INFINITY{INDENT_HTML_END*2}"
+        assert result[-2] == f"{INDENT_HTML_START*4}prev[v] ← u{INDENT_HTML_END*4}"
+        assert len(result) == 15
     
     def test_line_comment(self):
         limerick = dedent("""


### PR DESCRIPTION
Hello! First time contributor here. I haven't really worked with Anki extensions in the past but I think I got everything working.

The three core changes
* Add multiple indent handling (i.e. two tabs means two nested indent spans are generated)
* Upgrade to Qt6 (seems like other anki addons are doing this)
* [Fix Pushbutton bug](https://forums.ankiweb.net/t/mw-reset-throwing-wrapped-c-c-object-of-type-qpushbutton-has-been-deleted/16420)

## Full changes

Major changes:
* Add multiple indent handling in `_normalize_blank_lines`
* Update `technical.rst` with information about how multiple indents are handled
* Add unit test to `test_gen_notes.py` to determine how a code snippet would render
* Update `Makefile` to handle qt5 and qt6 file generation
* Update `lcpg_dialog.py`
  * Now works with Qt5 and Qt6
  * Calls `deckChoser.cleanup()` to address `QPushButton` deletion bug

Minor changes:
* Add import_dialog* to `.gitignore`
* Consolidate `requirements.txt` and `requirements_dev.txt`
* Fix misconfiguration of language in `conf.py`